### PR TITLE
implementando UserServicePort com JPA e ModelMapper

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Annotation profile for cycle-authenticate" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
             <artifactId>postgresql</artifactId>
             <version>42.7.8</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.modelmapper/modelmapper -->
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>3.2.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/stefanini/cycle_authenticate/domain/entities/User.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/domain/entities/User.java
@@ -29,6 +29,15 @@ public class User {
         this.dateOfBrith = dateOfBrith;
     }
 
+    public User(UUID id, String username, Email email, Password password, LocalDate dateOfBrith) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.dateOfBrith = dateOfBrith;
+    }
+
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/mappers/UserMapper.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/mappers/UserMapper.java
@@ -1,0 +1,52 @@
+package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.mappers;
+
+import com.stefanini.cycle_authenticate.domain.entities.User;
+import com.stefanini.cycle_authenticate.domain.value_objects.Email;
+import com.stefanini.cycle_authenticate.domain.value_objects.Password;
+import com.stefanini.cycle_authenticate.infra.adapters.outbound.database.models.UserModel;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    private ModelMapper modelMapper;
+
+    public UserMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    /**
+     * this.mapper.typeMap(UserEntity.class, User.class).addMappings(
+     * mapper ->{
+     * mapper.map(UserEntity::getName, User::setName);
+     * mapper.map(src-> Email.of(src.getEmail()) ,User::setEmail);
+     * mapper.map(UserEntity::getPassword, User::setPassword);
+     * mapper.map(src-> Role.valueOf(src.getRole()),User::setRole);
+     * }
+     * );
+     *
+     */
+    public User toDomain(UserModel userModel) {
+        this.modelMapper.typeMap(UserModel.class, User.class).addMappings(
+                modelMapper -> {
+                    modelMapper.map(model -> new Email(model.getEmail()), User::setEmail);
+                    modelMapper.map(model -> new Password(model.getPassword()), User::setPassword);
+                }
+        );
+
+        return this.modelMapper.map(userModel, User.class);
+    }
+
+    public UserModel toModel(User user) {
+        this.modelMapper.typeMap(User.class, UserModel.class).addMappings(
+                modelMapper -> {
+                    modelMapper.map(entity -> entity.getEmail().getValue(), UserModel::setEmail);
+                    modelMapper.map(entity -> entity.getPassword().getValue(), UserModel::setPassword);
+
+                }
+        );
+
+        return this.modelMapper.map(user, UserModel.class);
+    }
+}

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/models/UserModel.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/models/UserModel.java
@@ -1,0 +1,27 @@
+package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.models;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity(name = "users")
+public class UserModel {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String username;
+
+    private String email;
+
+
+    @Column(name = "password_hash")
+    private String password;
+
+    @Column(name = "date_of_brith")
+    private LocalDate dateOfBrith;
+
+}

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/models/UserModel.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/models/UserModel.java
@@ -1,11 +1,19 @@
 package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.models;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 @Entity(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserModel {
 
     @Id

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/JpaUserModelRepository.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/JpaUserModelRepository.java
@@ -1,0 +1,14 @@
+package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.repositories;
+
+
+import com.stefanini.cycle_authenticate.infra.adapters.outbound.database.models.UserModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaUserModelRepository extends JpaRepository<UserModel, UUID> {
+
+    Optional<UserModel> findByEmail(String email);
+
+}

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/UserRepositoryAdapter.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/UserRepositoryAdapter.java
@@ -1,4 +1,38 @@
 package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.repositories;
 
-public class UserRepositoryAdapter {
+import com.stefanini.cycle_authenticate.application.ports.outbound.repositories.UserRepositoryPort;
+import com.stefanini.cycle_authenticate.domain.entities.User;
+import com.stefanini.cycle_authenticate.domain.value_objects.Email;
+import com.stefanini.cycle_authenticate.infra.adapters.outbound.database.mappers.UserMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class UserRepositoryAdapter implements UserRepositoryPort {
+
+    private JpaUserModelRepository jpaUserModelRepository;
+
+    private UserMapper userMapper;
+
+    public UserRepositoryAdapter(JpaUserModelRepository jpaUserModelRepository, UserMapper userMapper) {
+        this.jpaUserModelRepository = jpaUserModelRepository;
+        this.userMapper = userMapper;
+    }
+
+    @Override
+    public Optional<User> save(User user) {
+        return Optional.of(this.userMapper.toDomain(this.jpaUserModelRepository.save(this.userMapper.toModel(user))));
+    }
+
+    @Override
+    public Optional<User> findByEmail(Email email) {
+        return this.jpaUserModelRepository.findByEmail(email.getValue()).map(model->this.userMapper.toDomain(model));
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return this.jpaUserModelRepository.findById(id).map(model-> this.userMapper.toDomain(model));
+    }
 }

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/UserRepositoryAdapter.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/adapters/outbound/database/repositories/UserRepositoryAdapter.java
@@ -1,0 +1,4 @@
+package com.stefanini.cycle_authenticate.infra.adapters.outbound.database.repositories;
+
+public class UserRepositoryAdapter {
+}

--- a/src/main/java/com/stefanini/cycle_authenticate/infra/configs/ModelMapperConfiguration.java
+++ b/src/main/java/com/stefanini/cycle_authenticate/infra/configs/ModelMapperConfiguration.java
@@ -1,0 +1,15 @@
+package com.stefanini.cycle_authenticate.infra.configs;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfiguration {
+
+    @Bean
+    ModelMapper modelMapper(){
+        return  new ModelMapper();
+    }
+
+}

--- a/src/main/resources/db/migration/V1__CREATE_TABLE_USERS.sql
+++ b/src/main/resources/db/migration/V1__CREATE_TABLE_USERS.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS users(
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) UNIQUE,
+    password_hash VARCHAR(512) NOT NULL,
+    date_of_brith TIMESTAMP
+);


### PR DESCRIPTION
realizei a implementação de uma porta da nossa aplicação com JPA e flyway para micrações e criações de tabelas além de mapear a mudança de entidades entre domain e infra , utilizei stacks como ModelMapper e Lombok para facilitar a conversão de entidades